### PR TITLE
Implement rm.common.generic

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -931,6 +931,10 @@ GROUPLIST_OPENEHR_AUDIT_CHANGE_TYPE = [
     CodePhrase(TERMINOLOGYID_OPENEHR, "817", "format conversion"),
     CodePhrase(TERMINOLOGYID_OPENEHR, "253", "unknown")
 ]
+GROUPLIST_OPENEHR_ATTESTATION_REASON = [
+    CodePhrase(TERMINOLOGYID_OPENEHR, "240", "signed"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "648", "witnessed")
+]
 
 CODESET_OPENEHR_CHARACTER_SETS = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_CHARACTER_SETS.name(), "en", CODELIST_OPENEHR_CHARACTER_SETS)
 CODESET_OPENEHR_COUNTRIES = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_COUNTRIES.name(), "en", CODELIST_OPENEHR_COUNTRIES)
@@ -945,5 +949,6 @@ TERMINOLOGY_OPENEHR = DictTerminologyAccess("openehr", "en", {
     ("subject_relationship", "subject relationship"): GROUPLIST_OPENEHR_SUBJECT_RELATIONSHIP,
     ("participation_function", "participation function"): GROUPLIST_OPENEHR_PARTICIPATION_FUNCTION,
     ("participation_mode", "participation mode"): GROUPLIST_OPENEHR_PARTICIPATION_MODE,
-    ("audit_change_type", "audit change type"): GROUPLIST_OPENEHR_AUDIT_CHANGE_TYPE
+    ("audit_change_type", "audit change type"): GROUPLIST_OPENEHR_AUDIT_CHANGE_TYPE,
+    ("attestation_reason", "attestation reason"): GROUPLIST_OPENEHR_ATTESTATION_REASON
 })

--- a/src/common.py
+++ b/src/common.py
@@ -845,6 +845,44 @@ GROUPLIST_OPENEHR_TERM_MAPPING_PURPOSES = [
     CodePhrase(TERMINOLOGYID_OPENEHR, "670", "reimbursement"),
     CodePhrase(TERMINOLOGYID_OPENEHR, "671", "research study")
 ]
+GROUPLIST_OPENEHR_SUBJECT_RELATIONSHIP = [
+    CodePhrase(TERMINOLOGYID_OPENEHR, "0", "self"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "3", "foetus"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "10", "mother"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "9", "father"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "6", "donor"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "253", "unknown"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "261", "adopted daughter"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "260", "adopted son"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "259", "adoptive father"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "258", "adoptive mother"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "256", "biological father"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "255", "biological mother"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "23", "brother"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "28", "child"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "265", "cohabitee"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "257", "cousin"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "29", "daughter"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "264", "guardian"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "39", "maternal aunt"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "8", "maternal grandfather"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "7", "maternal grandmother"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "38", "maternal uncle"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "189", "neonate"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "254", "parent"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "22", "partner/spouse"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "41", "paternal aunt"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "36", "paternal grandfather"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "37", "paternal grandmother"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "40", "paternal uncle"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "27", "sibling"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "24", "sister"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "31", "son"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "263", "step father"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "262", "step mother"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "25", "step or half brother"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "26", "step or half sister")
+]
 
 CODESET_OPENEHR_CHARACTER_SETS = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_CHARACTER_SETS.name(), "en", CODELIST_OPENEHR_CHARACTER_SETS)
 CODESET_OPENEHR_COUNTRIES = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_COUNTRIES.name(), "en", CODELIST_OPENEHR_COUNTRIES)
@@ -855,5 +893,6 @@ CODESET_OPENEHR_INTEGRITY_CEHCK_ALGORITHMS = ListCodeSetAccess(TERMINOLOGYID_OPE
 CODESET_OPENEHR_NORMAL_STATUSES = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_NORMAL_STATUSES.name(), "en", CODELIST_OPENEHR_NORMAL_STATUSES)
 
 TERMINOLOGY_OPENEHR = DictTerminologyAccess("openehr", "en", {
-    ("term_mapping_purpose", "term mapping purpose"): GROUPLIST_OPENEHR_TERM_MAPPING_PURPOSES
+    ("term_mapping_purpose", "term mapping purpose"): GROUPLIST_OPENEHR_TERM_MAPPING_PURPOSES,
+    ("subject_relationship", "subject relationship"): GROUPLIST_OPENEHR_SUBJECT_RELATIONSHIP
 })

--- a/src/common.py
+++ b/src/common.py
@@ -883,6 +883,43 @@ GROUPLIST_OPENEHR_SUBJECT_RELATIONSHIP = [
     CodePhrase(TERMINOLOGYID_OPENEHR, "25", "step or half brother"),
     CodePhrase(TERMINOLOGYID_OPENEHR, "26", "step or half sister")
 ]
+GROUPLIST_OPENEHR_PARTICIPATION_FUNCTION = [
+    CodePhrase(TERMINOLOGYID_OPENEHR, "253", "unknown")
+]
+GROUPLIST_OPENEHR_PARTICIPATION_MODE = [
+    CodePhrase(TERMINOLOGYID_OPENEHR, "193", "not specified"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "216", "face-to-face communication"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "223", "interpreted face-to-face communication"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "217", "signing (face-to-face)"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "195", "live audiovisual; videoconference; videophone"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "198", "videoconferencing"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "197", "videophone"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "218", "signing over video"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "224", "interpreted video communication"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "194", "asynchronous audiovisual; recorded video"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "196", "recorded video"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "202", "live audio-only; telephone; internet phone; teleconference"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "204", "telephone"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "203", "teleconference"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "205", "internet telephone"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "222", "interpreted audio-only"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "199", "asynchronous audio-only; dictated; voice mail"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "200", "dictated"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "201", "voice-mail"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "212", "live text-only; internet chat; SMS chat; interactive written note"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "213", "internet chat"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "214", "SMS chat"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "215", "interactive written note"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "206", "asynchronous text; email; fax; letter; handwritten note; SMS message"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "211", "handwritten note"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "210", "printed/typed letter"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "207", "email"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "208", "facsimile/telefax"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "221", "translated text"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "209", "SMS message"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "219", "physically present"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "220", "physically remote")
+]
 
 CODESET_OPENEHR_CHARACTER_SETS = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_CHARACTER_SETS.name(), "en", CODELIST_OPENEHR_CHARACTER_SETS)
 CODESET_OPENEHR_COUNTRIES = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_COUNTRIES.name(), "en", CODELIST_OPENEHR_COUNTRIES)
@@ -894,5 +931,7 @@ CODESET_OPENEHR_NORMAL_STATUSES = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_NORMAL
 
 TERMINOLOGY_OPENEHR = DictTerminologyAccess("openehr", "en", {
     ("term_mapping_purpose", "term mapping purpose"): GROUPLIST_OPENEHR_TERM_MAPPING_PURPOSES,
-    ("subject_relationship", "subject relationship"): GROUPLIST_OPENEHR_SUBJECT_RELATIONSHIP
+    ("subject_relationship", "subject relationship"): GROUPLIST_OPENEHR_SUBJECT_RELATIONSHIP,
+    ("participation_function", "participation function"): GROUPLIST_OPENEHR_PARTICIPATION_FUNCTION,
+    ("participation_mode", "participation mode"): GROUPLIST_OPENEHR_PARTICIPATION_MODE
 })

--- a/src/common.py
+++ b/src/common.py
@@ -920,6 +920,17 @@ GROUPLIST_OPENEHR_PARTICIPATION_MODE = [
     CodePhrase(TERMINOLOGYID_OPENEHR, "219", "physically present"),
     CodePhrase(TERMINOLOGYID_OPENEHR, "220", "physically remote")
 ]
+GROUPLIST_OPENEHR_AUDIT_CHANGE_TYPE = [
+    CodePhrase(TERMINOLOGYID_OPENEHR, "249", "creation"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "250", "amendment"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "251", "modification"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "252", "synthesis"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "523", "deleted"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "666", "attestation"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "816", "restoration"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "817", "format conversion"),
+    CodePhrase(TERMINOLOGYID_OPENEHR, "253", "unknown")
+]
 
 CODESET_OPENEHR_CHARACTER_SETS = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_CHARACTER_SETS.name(), "en", CODELIST_OPENEHR_CHARACTER_SETS)
 CODESET_OPENEHR_COUNTRIES = ListCodeSetAccess(TERMINOLOGYID_OPENEHR_COUNTRIES.name(), "en", CODELIST_OPENEHR_COUNTRIES)
@@ -933,5 +944,6 @@ TERMINOLOGY_OPENEHR = DictTerminologyAccess("openehr", "en", {
     ("term_mapping_purpose", "term mapping purpose"): GROUPLIST_OPENEHR_TERM_MAPPING_PURPOSES,
     ("subject_relationship", "subject relationship"): GROUPLIST_OPENEHR_SUBJECT_RELATIONSHIP,
     ("participation_function", "participation function"): GROUPLIST_OPENEHR_PARTICIPATION_FUNCTION,
-    ("participation_mode", "participation mode"): GROUPLIST_OPENEHR_PARTICIPATION_MODE
+    ("participation_mode", "participation mode"): GROUPLIST_OPENEHR_PARTICIPATION_MODE,
+    ("audit_change_type", "audit change type"): GROUPLIST_OPENEHR_AUDIT_CHANGE_TYPE
 })

--- a/src/org/openehr/rm/common/generic.py
+++ b/src/org/openehr/rm/common/generic.py
@@ -1,2 +1,81 @@
-class PartyIdentified:
-    pass
+"""
+The classes presented in this module are abstractions of concepts which are generic 
+patterns in the domain of health (and most likely other domains), such as 
+'participation' and 'attestation'
+"""
+
+from abc import abstractmethod
+from typing import Optional
+
+from org.openehr.base.foundation_types.any import AnyClass
+from org.openehr.base.resource import is_equal_value
+from org.openehr.base.base_types.identification import PartyRef
+from org.openehr.rm.data_types.basic import DVIdentifier
+
+class PartyProxy(AnyClass):
+    """Abstract concept of a proxy description of a party, including an optional link 
+    to data for this party in a demographic or other identity management system. Sub-typed 
+    into PARTY_IDENTIFIED and PARTY_SELF."""
+
+    external_ref: Optional[PartyRef]
+    """Optional reference to more detailed demographic or identification information for 
+    this party, in an external system."""
+
+    @abstractmethod
+    def __init__(self, external_ref: Optional[PartyRef] = None, **kwargs):
+        self.external_ref = external_ref
+        super().__init__(**kwargs)
+
+    @abstractmethod
+    def is_equal(self, other: 'PartyProxy'):
+        return (type(self) == type(other) and
+                self.external_ref.is_equal(other.external_ref))
+
+class PartySelf(PartyProxy):
+    """Party proxy representing the subject of the record. Used to indicate that the 
+    party is the owner of the record. May or may not have external_ref set."""
+
+    def __init__(self, external_ref: Optional[PartyRef] = None, **kwargs):
+        super().__init__(external_ref, **kwargs)
+
+    def is_equal(self, other):
+        return super().is_equal(other)
+
+class PartyIdentified(PartyProxy):
+    """Proxy data for an identified party other than the subject of the record, minimally 
+    consisting of human-readable identifier(s), such as name, formal (and possibly computable) 
+    identifiers such as NHS number, and an optional link to external data. There must be at 
+    least one of name, identifier or external_ref present.
+
+    Used to describe parties where only identifiers may be known, and there is no entry at all 
+    in the demographic system (or even no demographic system). Typically for health care providers,
+    e.g. name and provider number of an institution.
+
+    Should not be used to include patient identifying information."""
+
+    name: Optional[str]
+    """Optional human-readable name (in String form)."""
+
+    identifiers: Optional[list[DVIdentifier]]
+    """One or more formal identifiers (possibly computable)."""
+
+    def __init__(self, external_ref : Optional[PartyRef] = None, name : Optional[str] = None, identifiers : Optional[list[DVIdentifier]] = None, **kwargs):
+        if (external_ref is None and name is None and identifiers is None):
+            raise ValueError("Either an external_ref, a name or at least one identifier must be provided (invariant: basic_validity)")
+        
+        if (name is not None and name == ""):
+            raise ValueError("If name is provided, it must not be empty (invariant: name_valid)")
+        self.name = name
+
+        if (identifiers is not None and len(identifiers) == 0):
+            raise ValueError("If a list of identifiers is provided, it must not be emplty (invariant: identifiers_valid)")
+        
+        self.identifiers = identifiers
+        super().__init__(external_ref, **kwargs)
+
+    def is_equal(self, other: 'PartyIdentified'):
+        return (
+            super().is_equal(other) and
+            self.name == other.name and
+            is_equal_value(self.identifiers, other.identifiers)
+        )

--- a/src/org/openehr/rm/common/generic.py
+++ b/src/org/openehr/rm/common/generic.py
@@ -11,7 +11,9 @@ from org.openehr.base.foundation_types.any import AnyClass
 from org.openehr.base.resource import is_equal_value
 from org.openehr.base.base_types.identification import PartyRef
 from org.openehr.rm.data_types.basic import DVIdentifier
-from org.openehr.rm.data_types.text import DVCodedText
+from org.openehr.rm.data_types.quantity import DVInterval
+from org.openehr.rm.data_types.quantity.date_time import DVDateTime
+from org.openehr.rm.data_types.text import DVCodedText, DVText
 from org.openehr.rm.support.terminology import TerminologyService, util_verify_code_in_openehr_terminology_group_or_error, OpenEHRTerminologyGroupIdentifiers
 
 class PartyProxy(AnyClass):
@@ -108,3 +110,61 @@ class PartyRelated(PartyIdentified):
         )
         self.relationship = relationship
         super().__init__(external_ref, name, identifiers, **kwargs)
+
+class Participation(AnyClass):
+    """Model of a participation of a Party (any Actor or Role) in an activity. Used to represent 
+    any participation of a Party in some activity, which is not explicitly in the model, e.g. 
+    assisting nurse. Can be used to record past or future participations.
+
+    Should not be used in place of more permanent relationships between demographic entities."""
+
+    function: DVText
+    """The function of the Party in this participation (note that a given party might participate 
+    in more than one way in a particular activity). This attribute should be coded, but cannot be 
+    limited to the HL7v3:ParticipationFunction vocabulary, since it is too limited and 
+    hospital-oriented."""
+
+    mode: Optional[DVCodedText]
+    """Optional field for recording the 'mode' of the performer / activity interaction, e.g. 
+    present, by telephone, by email etc."""
+
+    performer: PartyProxy
+    """The id and possibly demographic system link of the party participating in the activity."""
+
+    time: Optional[DVInterval[DVDateTime]]
+    """The time interval during which the participation took place, if it is used in an 
+    observational context (i.e. recording facts about the past); or the intended time interval 
+    of the participation when used in future contexts, such as EHR Instructions."""
+
+    def __init__(self, function: DVText, performer: PartyProxy, mode: Optional[DVCodedText] = None, time: DVInterval[DVDateTime] = None, terminology_service: Optional[TerminologyService] = None, **kwargs):
+        if (isinstance(function, DVCodedText)):
+            if terminology_service is None:
+                raise ValueError("If provided function is DV_CODED_TEXT, then a terminology service must also be provided (invariant: function_valid)")
+            util_verify_code_in_openehr_terminology_group_or_error(
+                code=function.defining_code, 
+                terminology_group_id=OpenEHRTerminologyGroupIdentifiers.GROUP_ID_PARTICIPATION_FUNCTION, 
+                terminology_service=terminology_service,
+                invariant_name_for_error="function_valid")
+        
+        self.function = function
+        self.performer = performer
+
+        if (mode is not None):
+            if terminology_service is None:
+                raise ValueError("If mode is provided, then a terminology service must also be provided (invariant: mode_valid)")
+            util_verify_code_in_openehr_terminology_group_or_error(
+                code=mode.defining_code,
+                terminology_group_id=OpenEHRTerminologyGroupIdentifiers.GROUP_ID_PARTICIPATION_MODE,
+                terminology_service=terminology_service,
+                invariant_name_for_error="mode_valid"
+            )
+        self.mode = mode
+        self.time = time 
+        super().__init__(**kwargs)
+
+    def is_equal(self, other: 'Participation'):
+        return (type(self) == type(other) and
+                is_equal_value(self.function, other.function) and
+                is_equal_value(self.mode, other.mode) and
+                is_equal_value(self.performer, other.performer) and
+                is_equal_value(self.time, other.time))

--- a/src/org/openehr/rm/common/generic.py
+++ b/src/org/openehr/rm/common/generic.py
@@ -168,3 +168,60 @@ class Participation(AnyClass):
                 is_equal_value(self.mode, other.mode) and
                 is_equal_value(self.performer, other.performer) and
                 is_equal_value(self.time, other.time))
+    
+class AuditDetails(AnyClass):
+    """The set of attributes required to document the committal of an information item to a 
+    repository."""
+
+    system_id: str
+    """Identifier of the logical EHR system where the change was committed. This is almost 
+    always owned by the organisation legally responsible for the EHR, and is distinct from 
+    any application, or any hosting infrastructure."""
+
+    time_committed: DVDateTime
+    """Time of committal of the item."""
+
+    change_type: DVCodedText
+    """Type of change. Coded using the openEHR Terminology audit change type group."""
+
+    description: Optional[DVText]
+    """Reason for committal. This may be used to qualify the value in the change_type 
+    field. For example, if the change affects only the EHR directory, this field might 
+    be used to indicate 'Folder "episode 2018-02-16" added' or similar."""
+
+    committer: PartyProxy
+    """Identity and optional reference into identity management service, of user who 
+    committed the item."""
+
+    def __init__(self, 
+                 system_id: str, 
+                 time_committed: DVDateTime, 
+                 change_type: DVCodedText, 
+                 committer: PartyProxy, 
+                 terminology_service: TerminologyService,
+                 description: Optional[DVText] = None, 
+                 **kwargs):
+        if len(system_id) == 0:
+            raise ValueError("system_id cannot be empty (invariant: system_id_valid)")
+        self.system_id = system_id
+        self.time_committed = time_committed
+        util_verify_code_in_openehr_terminology_group_or_error(
+            code=change_type.defining_code,
+            terminology_group_id=OpenEHRTerminologyGroupIdentifiers.GROUP_ID_AUDIT_CHANGE_TYPE,
+            terminology_service=terminology_service,
+            invariant_name_for_error="change_type_valid"
+        )
+        self.change_type = change_type
+        self.committer = committer
+        self.description = description
+        super().__init__(**kwargs)
+
+    def is_equal(self, other: 'AuditDetails'):
+        return (
+            type(self) == type(other) and
+            self.system_id == other.system_id and
+            is_equal_value(self.time_committed, other.time_committed) and
+            is_equal_value(self.change_type, other.change_type) and
+            is_equal_value(self.description, other.description) and
+            is_equal_value(self.committer, other.committer)
+        )

--- a/src/org/openehr/rm/data_types/quantity/__init__.py
+++ b/src/org/openehr/rm/data_types/quantity/__init__.py
@@ -157,7 +157,7 @@ class DVOrdered(DataValue):
     def __str__(self):
         return str(self._value)
 
-class DVInterval(DataValue):
+class DVInterval[T](DataValue):
     """Generic class defining an interval (i.e. range) of a comparable type. An interval is a 
     contiguous subrange of a comparable base type. Used to define intervals of dates, times, 
     quantities (whose units match) and so on. The type parameter, T, must be a descendant of the 
@@ -174,7 +174,7 @@ class DVInterval(DataValue):
     # invariant limits_consistent met because all subclasses of Interval check that lower and upper
     #  bounds have the same type
 
-    value: Interval[DVOrdered]
+    value: Interval[T]
 
     def _attempt_set_value(self, value: Interval[DVOrdered]):
         if ((value.lower is not None) and (not isinstance(value.lower, DVOrdered))) or ((value.upper is not None) and (not isinstance(value.upper, DVOrdered))):

--- a/src/org/openehr/rm/support/terminology.py
+++ b/src/org/openehr/rm/support/terminology.py
@@ -43,6 +43,7 @@ class OpenEHRTerminologyGroupIdentifiers:
     GROUP_ID_NULL_FLAVOURS = "null_flavours"
     GROUP_ID_PROPERTY = "property"
     GROUP_ID_PARTICIPATION_FUNCTION = "participation_function"
+    GROUP_ID_PARTICIPATION_MODE = "participation_mode"
     GROUP_ID_SETTING = "setting"
     GROUP_ID_TERM_MAPPING_PURPOSE = "term_mapping_purpose"
     GROUP_ID_SUBJECT_RELATIONSHIP = "subject_relationship"
@@ -62,6 +63,7 @@ class OpenEHRTerminologyGroupIdentifiers:
             (an_id == OpenEHRTerminologyGroupIdentifiers.GROUP_ID_NULL_FLAVOURS) or
             (an_id == OpenEHRTerminologyGroupIdentifiers.GROUP_ID_PROPERTY) or
             (an_id == OpenEHRTerminologyGroupIdentifiers.GROUP_ID_PARTICIPATION_FUNCTION) or
+            (an_id == OpenEHRTerminologyGroupIdentifiers.GROUP_ID_PARTICIPATION_MODE) or
             (an_id == OpenEHRTerminologyGroupIdentifiers.GROUP_ID_SETTING) or
             (an_id == OpenEHRTerminologyGroupIdentifiers.GROUP_ID_TERM_MAPPING_PURPOSE) or
             (an_id == OpenEHRTerminologyGroupIdentifiers.GROUP_ID_SUBJECT_RELATIONSHIP) or
@@ -202,6 +204,8 @@ def util_verify_code_in_openehr_terminology_group_or_error(code: CodePhrase, ter
     if (not terminology_service.has_terminology(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR)):
         raise ValueError(f"Access to a TerminologyService with OpenEHR terminology must also be given to check validity {"(invariant: " + invariant_name_for_error + ")" if invariant_name_for_error else ""}")
     else:
+        if not code.terminology_id.name() == OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR:
+            raise ValueError(f"Provided code used the terminology \'{code.terminology_id.name()}\' rather then 'openehr' {"(invariant: " + invariant_name_for_error + ")" if invariant_name_for_error else ""}")
         openehr_terminology = terminology_service.terminology(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR)
         if not openehr_terminology.has_code_for_group_id(code.code_string, terminology_group_id):
             raise ValueError(f"Provided code \'{code.code_string}\' was not in the OpenEHR \'{terminology_group_id}\' terminology group {"(invariant: " + invariant_name_for_error + ")" if invariant_name_for_error else ""}")

--- a/test/org/openehr/rm/common/test_generic.py
+++ b/test/org/openehr/rm/common/test_generic.py
@@ -1,8 +1,8 @@
 import pytest
 
 from common import PythonTerminologyService, TERMINOLOGY_OPENEHR
-from org.openehr.base.base_types.identification import PartyRef, ObjectID, TerminologyID
-from org.openehr.rm.common.generic import PartyIdentified, PartyRelated, Participation, AuditDetails, Attestation
+from org.openehr.base.base_types.identification import PartyRef, ObjectID, TerminologyID, ObjectVersionID
+from org.openehr.rm.common.generic import PartyIdentified, PartyRelated, Participation, AuditDetails, Attestation, RevisionHistory, RevisionHistoryItem
 from org.openehr.rm.data_types.basic import DVIdentifier
 from org.openehr.rm.data_types.text import DVCodedText, CodePhrase, DVText
 from org.openehr.rm.data_types.quantity.date_time import DVDateTime
@@ -228,3 +228,44 @@ def test_attestation_reason_valid():
             is_pending=False,
             terminology_service=ts_empty
         )
+
+valid_rh_example = RevisionHistory([
+        RevisionHistoryItem(
+            version_id=ObjectVersionID("1d34aa7a-9e2c-49ff-a539-53c926107df6::ehr.example.net::1"),
+            audits=[
+                AuditDetails(
+                    system_id="ehr.example.net",
+                    time_committed=DVDateTime("2025-09-21T18:20:00Z"),
+                    change_type=DVCodedText("created initial draft", CodePhrase(TerminologyID("openehr"), "249", "creation")),
+                    committer=PartyIdentified(name="Dr A General-Practitioner"),
+                    terminology_service=ts_ok
+                    ),
+                Attestation(
+                    system_id="ehr.example.net",
+                    time_committed=DVDateTime("2025-09-21T18:22:00Z"),
+                    change_type=DVCodedText("signed DNACPR section", CodePhrase(TerminologyID("openehr"), "666", "attestation")),
+                    committer=PartyIdentified(name="Dr A General-Practitioner"),
+                    reason=DVCodedText("signed", CodePhrase(TerminologyID("openehr"), "240", "signed")),
+                    is_pending=False,
+                    terminology_service=ts_ok
+                )
+            ]),
+        RevisionHistoryItem(
+            version_id=ObjectVersionID("1d34aa7a-9e2c-49ff-a539-53c926107df6::ehr.example.net::2"),
+            audits=[
+                AuditDetails(
+                    system_id="ehr.example.net",
+                    time_committed=DVDateTime("2025-09-21T18:32:00Z"),
+                    change_type=DVCodedText("amended preferred name", CodePhrase(TerminologyID("openehr"), "250", "amendment")),
+                    committer=PartyIdentified(name="Ms C Test"),
+                    terminology_service=ts_ok
+                )
+            ]
+        )
+    ])
+
+def test_revision_history_most_recent_version():
+    assert valid_rh_example.most_recent_version() == "1d34aa7a-9e2c-49ff-a539-53c926107df6::ehr.example.net::2"
+
+def test_revision_history_most_recent_version_time_committed():
+    assert valid_rh_example.most_recent_version_time_committed() == "2025-09-21T18:32:00Z"

--- a/test/org/openehr/rm/common/test_generic.py
+++ b/test/org/openehr/rm/common/test_generic.py
@@ -1,0 +1,31 @@
+import pytest
+
+from org.openehr.base.base_types.identification import PartyRef, ObjectID
+from org.openehr.rm.common.generic import PartyIdentified
+from org.openehr.rm.data_types.basic import DVIdentifier
+
+def test_party_identified_basic_validity():
+    # OK (one of three not void)
+    pi = PartyIdentified(external_ref=PartyRef("gmc_number", "PERSON", ObjectID("9999999")))
+    pi = PartyIdentified(name="Dr. Test Example")
+    pi = PartyIdentified(identifiers=[DVIdentifier("9999999", issuer="General Medical Council")])
+
+    # not OK (all void)
+    with pytest.raises(ValueError):
+        pi = PartyIdentified()
+
+def test_party_identified_name_valid():
+    # OK (name not empty)
+    pi = PartyIdentified(name="Dr. Test Example")
+
+    # not OK (name empty)
+    with pytest.raises(ValueError):
+        pi = PartyIdentified(name="")
+
+def test_party_identified_identifiers_valid():
+    # OK (list of identifiers not empty)
+    pi = PartyIdentified(identifiers=[DVIdentifier("9999999", issuer="General Medical Council")])
+
+    # not OK (identifiers empty)
+    with pytest.raises(ValueError):
+        pi = PartyIdentified(identifiers=[])

--- a/test/org/openehr/rm/common/test_generic.py
+++ b/test/org/openehr/rm/common/test_generic.py
@@ -2,9 +2,10 @@ import pytest
 
 from common import PythonTerminologyService, TERMINOLOGY_OPENEHR
 from org.openehr.base.base_types.identification import PartyRef, ObjectID, TerminologyID
-from org.openehr.rm.common.generic import PartyIdentified, PartyRelated, Participation
+from org.openehr.rm.common.generic import PartyIdentified, PartyRelated, Participation, AuditDetails
 from org.openehr.rm.data_types.basic import DVIdentifier
 from org.openehr.rm.data_types.text import DVCodedText, CodePhrase, DVText
+from org.openehr.rm.data_types.quantity.date_time import DVDateTime
 from org.openehr.rm.support.terminology import OpenEHRTerminologyGroupIdentifiers
 
 ts_ok = PythonTerminologyService(code_sets=[], terminologies=[TERMINOLOGY_OPENEHR])
@@ -110,3 +111,50 @@ def test_participation_mode_valid():
             function=DVText("observer"), 
             performer=PartyIdentified(name="Ms. A Student"),
             mode=DVCodedText("physically present", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "219", "physically present")))
+        
+def test_audit_details_system_id_valid():
+    # OK
+    AuditDetails(
+        system_id="example_hospital_ehr",
+        time_committed=DVDateTime("2025-09-21T15:58:02.128Z"),
+        change_type=DVCodedText("creation", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "249", "creation")),
+        committer=PartyIdentified(external_ref=PartyRef("local_active_directory", "PERSON", ObjectID("TU999"))),
+        terminology_service=ts_ok
+    )
+    # not OK (system_id empty string)
+    with pytest.raises(ValueError):
+        AuditDetails(
+            system_id="",
+            time_committed=DVDateTime("2025-09-21T15:58:02.128Z"),
+            change_type=DVCodedText("creation", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "249", "creation")),
+            committer=PartyIdentified(external_ref=PartyRef("local_active_directory", "PERSON", ObjectID("TU999"))),
+            terminology_service=ts_ok
+        )
+
+def test_audit_details_change_type_valid():
+    # OK
+    AuditDetails(
+        system_id="example_hospital_ehr",
+        time_committed=DVDateTime("2025-09-21T15:58:02.128Z"),
+        change_type=DVCodedText("creation", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "249", "creation")),
+        committer=PartyIdentified(external_ref=PartyRef("local_active_directory", "PERSON", ObjectID("TU999"))),
+        terminology_service=ts_ok
+    )
+    # not OK (invalid code)
+    with pytest.raises(ValueError):
+        AuditDetails(
+            system_id="example_hospital_ehr",
+            time_committed=DVDateTime("2025-09-21T15:58:02.128Z"),
+            change_type=DVCodedText("creation", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "524", "initial")),
+            committer=PartyIdentified(external_ref=PartyRef("local_active_directory", "PERSON", ObjectID("TU999"))),
+            terminology_service=ts_ok
+        )
+    # not OK (empty ts)
+    with pytest.raises(ValueError):
+        AuditDetails(
+            system_id="example_hospital_ehr",
+            time_committed=DVDateTime("2025-09-21T15:58:02.128Z"),
+            change_type=DVCodedText("creation", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "524", "initial")),
+            committer=PartyIdentified(external_ref=PartyRef("local_active_directory", "PERSON", ObjectID("TU999"))),
+            terminology_service=ts_empty
+        )

--- a/test/org/openehr/rm/common/test_generic.py
+++ b/test/org/openehr/rm/common/test_generic.py
@@ -1,8 +1,14 @@
 import pytest
 
-from org.openehr.base.base_types.identification import PartyRef, ObjectID
-from org.openehr.rm.common.generic import PartyIdentified
+from common import PythonTerminologyService, TERMINOLOGY_OPENEHR
+from org.openehr.base.base_types.identification import PartyRef, ObjectID, TerminologyID
+from org.openehr.rm.common.generic import PartyIdentified, PartyRelated
 from org.openehr.rm.data_types.basic import DVIdentifier
+from org.openehr.rm.data_types.text import DVCodedText, CodePhrase
+from org.openehr.rm.support.terminology import OpenEHRTerminologyGroupIdentifiers
+
+ts_ok = PythonTerminologyService(code_sets=[], terminologies=[TERMINOLOGY_OPENEHR])
+ts_empty = PythonTerminologyService(code_sets=[], terminologies=[])
 
 def test_party_identified_basic_validity():
     # OK (one of three not void)
@@ -29,3 +35,24 @@ def test_party_identified_identifiers_valid():
     # not OK (identifiers empty)
     with pytest.raises(ValueError):
         pi = PartyIdentified(identifiers=[])
+
+def test_party_related_relationship_valid():
+    PartyRelated(
+        relationship=DVCodedText("mum", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "10", "mother")),
+        terminology_service=ts_ok,
+        name="Ms. A Example"
+        )
+    # not OK (term svc without openehr)
+    with pytest.raises(ValueError):
+        PartyRelated(
+            relationship=DVCodedText("mum", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "10", "mother")),
+            terminology_service=ts_empty,
+            name="Ms. A Example"
+            )
+    # not OK (code not in terminology group)
+    with pytest.raises(ValueError):
+        PartyRelated(
+            relationship=DVCodedText("mum", CodePhrase(TerminologyID(OpenEHRTerminologyGroupIdentifiers.TERMINOLOGY_ID_OPENEHR), "1000", "mum")),
+            terminology_service=ts_ok,
+            name="Ms. A Example"
+            )

--- a/test/org/openehr/rm/data_types/test_text.py
+++ b/test/org/openehr/rm/data_types/test_text.py
@@ -19,24 +19,24 @@ def test_code_phrase_code_string_valid():
         code = CodePhrase(term_id, "", "Respiratory tuberculosis, bacteriologically and histologically confirmed")
 
 def test_term_mapping_purpose_valid():
-    tmp = DVCodedText("research study", CodePhrase("openehr", "671", "research study"))
-    invalid_tmp = DVCodedText("organisational policy", CodePhrase("openehr", "100000", "organisational policy"))
+    tmp = DVCodedText("research study", CodePhrase(TerminologyID("openehr"), "671", "research study"))
+    invalid_tmp = DVCodedText("organisational policy", CodePhrase(TerminologyID("openehr"), "100000", "organisational policy"))
 
     # should be OK
-    tm = TermMapping('>', CodePhrase("SNOMED-CT", "159412009", "Manager - supermarket (occupation)"))
-    tm = TermMapping('>', CodePhrase("SNOMED-CT", "159412009", "Manager - supermarket (occupation)"), purpose=tmp, terminology_service=test_ts)
+    tm = TermMapping('>', CodePhrase(TerminologyID("SNOMED-CT"), "159412009", "Manager - supermarket (occupation)"))
+    tm = TermMapping('>', CodePhrase(TerminologyID("SNOMED-CT"), "159412009", "Manager - supermarket (occupation)"), purpose=tmp, terminology_service=test_ts)
 
     # not OK (no terminology service provided)
     with pytest.raises(ValueError):
-        tm = TermMapping('>', CodePhrase("SNOMED-CT", "159412009", "Manager - supermarket (occupation)"), purpose=tmp)
+        tm = TermMapping('>', CodePhrase(TerminologyID("SNOMED-CT"), "159412009", "Manager - supermarket (occupation)"), purpose=tmp)
 
     # not OK (terminology service doesn't have OpenEHR)
     with pytest.raises(ValueError):
-        tm = TermMapping('>', CodePhrase("SNOMED-CT", "159412009", "Manager - supermarket (occupation)"), purpose=tmp, terminology_service=test_ts_empty)
+        tm = TermMapping('>', CodePhrase(TerminologyID("SNOMED-CT"), "159412009", "Manager - supermarket (occupation)"), purpose=tmp, terminology_service=test_ts_empty)
 
     # not OK (invalid purpose code provided)
     with pytest.raises(ValueError):
-        tm = TermMapping('>', CodePhrase("SNOMED-CT", "159412009", "Manager - supermarket (occupation)"), purpose=invalid_tmp, terminology_service=test_ts)
+        tm = TermMapping('>', CodePhrase(TerminologyID("SNOMED-CT"), "159412009", "Manager - supermarket (occupation)"), purpose=invalid_tmp, terminology_service=test_ts)
 
 def test_term_mapping_is_valid_code():
     tmp = TermMapping('?', CodePhrase("SNOMED-CT", "257256000", "Supermarket shopping cart (physical object)"))


### PR DESCRIPTION
Implemented the classes in the generic package, namely:
* PARTY_PROXY
* PARTY_SELF
* PARTY_IDENTIFIED
* PARTY_RELATED
* PARTICIPATION
* AUDIT_DETAILS
* ATTESTATION
* REVISION_HISTORY
* REVISION_HISTORY_ITEM

Added a check for correct terminology ID when checking openehr terminology in the utils.